### PR TITLE
Download vizgen_merscope sample

### DIFF
--- a/vizgen_merscope/README.md
+++ b/vizgen_merscope/README.md
@@ -1,1 +1,1 @@
-Data specs is changing and did not manage to use the google cloud api for programmatic download.
+New vizgen data structure (with VPT outputs)

--- a/vizgen_merscope/align.py
+++ b/vizgen_merscope/align.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import geopandas
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from PIL import Image
+
+path = Path(__file__).parents[1] / "data" / "vizgen_sample"
+images_dir = path / "images"
+
+microns_to_pixels = np.genfromtxt(images_dir / "micron_to_mosaic_pixel_transform.csv")
+
+image = np.stack(
+	[
+		np.array(Image.open(images_dir / name))
+		for name in [
+			"mosaic_DAPI_z3.tif",
+			"mosaic_stain1_z3.tif",
+			"mosaic_stain2_z3.tif",
+		]
+	],
+	axis=2,
+)
+
+transcripts = pd.read_csv(path / "detected_transcripts.csv")
+coords = np.concatenate(
+	[transcripts[["global_x", "global_y"]].values, np.ones((len(transcripts), 1))],
+	axis=1,
+)
+pixels_coords = (coords @ microns_to_pixels.T)[:, :2]
+pixels_coords = pixels_coords[
+	np.random.choice(len(pixels_coords), 10_000, replace=False)
+]  # Subsample 10k transcripts
+
+geo_df = geopandas.read_parquet(path / "vpt-run" / "cellpose_micron_space.parquet")
+
+### Plot image + transcripts + boundaries
+plt.figure(figsize=(12, 12))
+plt.imshow(image.clip(0, 40_000) / 40_000)
+plt.scatter(pixels_coords[:, 0], pixels_coords[:, 1], s=1, c="k")
+
+for geom in geo_df[geo_df.ZIndex == 0].Geometry:
+	x, y = geom.geoms[0].exterior.coords.xy
+	x, y = (
+		np.stack([x, y], axis=1) @ microns_to_pixels[:2, :2] + microns_to_pixels[:2, 2]
+	).T
+	plt.plot(x, y, "w", linewidth=0.5)
+
+plt.savefig("cropped_images_aligned.png")
+

--- a/vizgen_merscope/align.py
+++ b/vizgen_merscope/align.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 from PIL import Image
 
-path = Path(__file__).parents[1] / "data" / "vizgen_sample"
+path = Path(__file__).parents[0] / "data" / "vizgen_sample"
 images_dir = path / "images"
 
 microns_to_pixels = np.genfromtxt(images_dir / "micron_to_mosaic_pixel_transform.csv")
@@ -28,6 +28,7 @@ coords = np.concatenate(
 	[transcripts[["global_x", "global_y"]].values, np.ones((len(transcripts), 1))],
 	axis=1,
 )
+
 pixels_coords = (coords @ microns_to_pixels.T)[:, :2]
 pixels_coords = pixels_coords[
 	np.random.choice(len(pixels_coords), 10_000, replace=False)
@@ -43,9 +44,10 @@ plt.scatter(pixels_coords[:, 0], pixels_coords[:, 1], s=1, c="k")
 for geom in geo_df[geo_df.ZIndex == 0].Geometry:
 	x, y = geom.geoms[0].exterior.coords.xy
 	x, y = (
-		np.stack([x, y], axis=1) @ microns_to_pixels[:2, :2] + microns_to_pixels[:2, 2]
+		np.stack([x, y], axis=1) @ microns_to_pixels[:2, :2].T + microns_to_pixels[:2, 2]
 	).T
 	plt.plot(x, y, "w", linewidth=0.5)
 
+plt.show()
 plt.savefig("cropped_images_aligned.png")
 

--- a/vizgen_merscope/download.py
+++ b/vizgen_merscope/download.py
@@ -1,0 +1,18 @@
+import subprocess
+from pathlib import Path
+
+
+def main():
+    URL = Path("https://zenodo.org/record/7852005/files/vizgen_sample.zip")
+
+    zip_path = Path(__file__).parents[1] / "data" / URL.name
+    folder_path = Path(__file__).parents[1] / "data" / URL.stem
+    zip_path.parent.mkdir(exist_ok=True)
+
+    command = f"curl {URL} --output '{zip_path}'"
+    subprocess.run(command, shell=True, check=True)
+    subprocess.run(f"unzip {zip_path} -d {folder_path}", shell=True, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/vizgen_merscope/download.py
+++ b/vizgen_merscope/download.py
@@ -5,8 +5,8 @@ from pathlib import Path
 def main():
     URL = Path("https://zenodo.org/record/7852005/files/vizgen_sample.zip")
 
-    zip_path = Path(__file__).parents[1] / "data" / URL.name
-    folder_path = Path(__file__).parents[1] / "data" / URL.stem
+    zip_path = Path(__file__).parent / "data" / URL.name
+    folder_path = Path(__file__).parent / "data" / URL.stem
     zip_path.parent.mkdir(exist_ok=True)
 
     command = f"curl {URL} --output '{zip_path}'"

--- a/vizgen_merscope/to_zarr.py
+++ b/vizgen_merscope/to_zarr.py
@@ -1,21 +1,30 @@
 import shutil
 from pathlib import Path
 
-from spatialdata_io import merfish
+from spatialdata_io import merscope
 
 
 def main():
     sample_path = Path(__file__).parent / "data" / "vizgen_sample"
     zarr_path = Path(__file__).parent / "data.zarr"
 
-    sdata = merfish(sample_path, vpt_outputs=sample_path / "vpt-run")
+    sdata = merscope(sample_path, vpt_outputs=sample_path / "vpt-run")
 
     if zarr_path.exists():
         shutil.rmtree(zarr_path)
     sdata.write(zarr_path)
 
-    print(f"Saved merfish data:\n{sdata}")
+    print(f"Saved merscope data:\n{sdata}")
+
+
+def viz():
+    from spatialdata import read_zarr
+    from napari_spatialdata import Interactive
+
+    sdata = read_zarr(Path(__file__).parent / "data.zarr")
+    Interactive(sdata).run()
 
 
 if __name__ == "__main__":
     main()
+    # viz()

--- a/vizgen_merscope/to_zarr.py
+++ b/vizgen_merscope/to_zarr.py
@@ -1,19 +1,19 @@
+import shutil
 from pathlib import Path
 
 from spatialdata_io import merfish
 
 
 def main():
-    sample_path = Path(__file__).parents[1] / "data" / "vizgen_sample"
+    sample_path = Path(__file__).parent / "data" / "vizgen_sample"
     zarr_path = Path(__file__).parent / "data.zarr"
 
-    if zarr_path.exists():
-        print(f"Zarr folder already existing at {zarr_path}. Exiting.")
-        return
-
     sdata = merfish(sample_path, vpt_outputs=sample_path / "vpt-run")
+
+    if zarr_path.exists():
+        shutil.rmtree(zarr_path)
     sdata.write(zarr_path)
-    
+
     print(f"Saved merfish data:\n{sdata}")
 
 

--- a/vizgen_merscope/to_zarr.py
+++ b/vizgen_merscope/to_zarr.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from spatialdata_io import merfish
+
+
+def main():
+    sample_path = Path(__file__).parents[1] / "data" / "vizgen_sample"
+    zarr_path = Path(__file__).parent / "data.zarr"
+
+    if zarr_path.exists():
+        print(f"Zarr folder already existing at {zarr_path}. Exiting.")
+        return
+
+    sdata = merfish(sample_path, vpt_outputs=sample_path / "vpt-run")
+    sdata.write(zarr_path)
+    
+    print(f"Saved merfish data:\n{sdata}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added to `vizgen_merscope`:
- `download.py`: download and unzip a file from Zenodo
- `to_zarr.py`: make a zarr folder (using the merfish reader in spatialdata-io, see PR: https://github.com/scverse/spatialdata-io/pull/33)

NB: for ease of sharing, this is a very small crop of a public vizgen image, and some channels were removed to make it lighter. Since VPT (https://vizgen.github.io/vizgen-postprocessing/) was run on this crop, it gave the **latest file format/structure** into a dedicated subfolder that I called `vpt-run`.