### PR TITLE
Add image fusion notebook

### DIFF
--- a/notebooks/spatialdata_fusion.ipynb
+++ b/notebooks/spatialdata_fusion.ipynb
@@ -1,0 +1,870 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "from functools import partial\n",
+    "from pathlib import Path\n",
+    "from zipfile import ZipFile\n",
+    "\n",
+    "import dask.array as da\n",
+    "from dask.array.core import normalize_chunks\n",
+    "import numpy as np\n",
+    "from shapely.geometry import GeometryCollection, Point\n",
+    "from skimage.transform import AffineTransform\n",
+    "\n",
+    "from fuse.fuse import fuse_func\n",
+    "from utils.download_sample import download_from_dropbox\n",
+    "from utils.metadata import extract_coordinates, normalize_coords_to_pixel\n",
+    "from utils.imutils import crop_black_border, load_image, transpose\n",
+    "from utils.shapely_and_napari_utils import get_transformed_array_corners, numpy_shape_to_shapely\n",
+    "from utils.chunks import get_chunk_coordinates, get_rect_from_chunk_boundary, find_chunk_tile_intersections"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overview: creating a single, fused array from many image tiles that have associated affine transfomations.\n",
+    "\n",
+    "This notebook demonstrates how dask's `map_blocks` can be leveraged to combine many images that have associated affine or perspective transforms into a single array. \n",
+    "\n",
+    "This is a scenario that is common when building image mosaics, e.g. a landscape panorama from multiple photos or a picture of part of a microscope slide combined from many individual microscope images.\n",
+    "\n",
+    "For the sake of the notebook we assume that the spatial transformations that map the individual tiles into a common coordinate system are already known. Here, we don't discuss how to find these transforms, which could be done  through methods such as feature point matching and bundle adjustment or normalized cross corellation.\n",
+    "\n",
+    "Instead, we focus on how dasks `map_blocks` can help with the process of fusing the individual tiles into a single array efficiently, especially for cases when the resulting output array is too large to fit in RAM.\n",
+    "\n",
+    "To visualize the position of individual image tiles in this notebook we represent them as shapely objects.\n",
+    "This also facilitates finding image tiles intersecting chunks in a dask array, which we also represent as shapely objects.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Download sample dataset\n",
+    "\n",
+    "The following code cell downloads the sample dataset used in this notebook.\n",
+    "\n",
+    "### Dataset description\n",
+    "The sample dataset consists of a number of brighfield microscopy images. These are individual image tiles captured of a microscope slide that has previously been used for MALDI imaging. On the slide there are some visible pen-marks (used as fiducials) and a grid of laser ablation marks from the MALDI laser. \n",
+    "\n",
+    "To reduce the download size of the example dataset the image tiles have been converted to `.jpg`, which is not part of the usual workflow. Also the dataset here contains only 72 tiles, covering only a small part of a microscope slide. The outlined workflow scales to much larger numbers of tiles.\n",
+    "\n",
+    "In addition to the image tiles there is an `out.txt` file that contains image metadata. Of this metadata we use the pixel scale and the stage position for each tile. Note that the stage positions are not accurate enough to enable pixel-accurate registration of the tiles. \n",
+    "\n",
+    "The sample has been prepared and imaged by Mohammed Shahraz from the Alexandrov lab at EMBL Heidelberg.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/michal/.mambaforge/envs/hackathon/lib/python3.10/site-packages/geopandas/_compat.py:123: UserWarning: The Shapely GEOS version (3.11.1-CAPI-1.17.1) is incompatible with the GEOS version PyGEOS was compiled with (3.10.4-CAPI-1.16.2). Conversions between both will be slow.\n",
+      "  warnings.warn(\n",
+      "/Users/michal/Projects/hackathon/spatial/spatialdata/src/spatialdata/__init__.py:9: UserWarning: Geopandas was set to use PyGEOS, changing to shapely 2.0 with:\n",
+      "\n",
+      "\tgeopandas.options.use_pygeos = True\n",
+      "\n",
+      "If you intended to use PyGEOS, set the option to False.\n",
+      "  _check_geopandas_using_shapely()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34mINFO    \u001b[0m `dims` is specified redundantly: found also inside `data`.                                                \n",
+      "\u001b[34mINFO    \u001b[0m Transposing `data` of type: \u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'xarray.core.dataarray.DataArray'\u001b[0m\u001b[1m>\u001b[0m to \u001b[1m(\u001b[0m\u001b[32m'c'\u001b[0m, \u001b[32m'y'\u001b[0m, \u001b[32m'x'\u001b[0m\u001b[1m)\u001b[0m.                 \n",
+      "\u001b[34mINFO    \u001b[0m `dims` is specified redundantly: found also inside `data`.                                                \n",
+      "\u001b[34mINFO    \u001b[0m Transposing `data` of type: \u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'xarray.core.dataarray.DataArray'\u001b[0m\u001b[1m>\u001b[0m to \u001b[1m(\u001b[0m\u001b[32m'c'\u001b[0m, \u001b[32m'y'\u001b[0m, \u001b[32m'x'\u001b[0m\u001b[1m)\u001b[0m.                 \n",
+      "\u001b[34mINFO    \u001b[0m `dims` is specified redundantly: found also inside `data`.                                                \n",
+      "\u001b[34mINFO    \u001b[0m Transposing `data` of type: \u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'xarray.core.dataarray.DataArray'\u001b[0m\u001b[1m>\u001b[0m to \u001b[1m(\u001b[0m\u001b[32m'c'\u001b[0m, \u001b[32m'y'\u001b[0m, \u001b[32m'x'\u001b[0m\u001b[1m)\u001b[0m.                 \n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "SpatialData object with:\n",
+       "└── Images\n",
+       "      ├── 'im0': SpatialImage[cyx] (3, 5120, 5120)\n",
+       "      ├── 'im1': SpatialImage[cyx] (3, 5120, 5120)\n",
+       "      └── 'im2': SpatialImage[cyx] (3, 5120, 5120)\n",
+       "with coordinate systems:\n",
+       "▸ 'global', with elements:\n",
+       "        im0 (Images), im1 (Images), im2 (Images)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "##\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from skimage import data\n",
+    "from dask_image.ndinterp import affine_transform as affine_transform_dask\n",
+    "from xarray import DataArray\n",
+    "\n",
+    "image = data.astronaut()\n",
+    "image = DataArray(image, dims=[\"y\", \"x\", \"c\"])\n",
+    "\n",
+    "scale_factor = 10\n",
+    "matrix = np.array(\n",
+    "    [\n",
+    "        [1.0 / scale_factor, 0, 0, 0],\n",
+    "        [0, 1.0 / scale_factor, 0, 0],\n",
+    "        [0, 0, 1, 0],\n",
+    "        [0, 0, 0, 1],\n",
+    "    ]\n",
+    ")\n",
+    "output_shape = (image.shape[0] * scale_factor, image.shape[1] * scale_factor, 3)\n",
+    "image_transformed = affine_transform_dask(\n",
+    "    image.data,\n",
+    "    matrix=matrix,\n",
+    "    output_shape=output_shape,\n",
+    ")\n",
+    "image_transformed = DataArray(image_transformed, dims=(\"y\", \"x\", \"c\"))\n",
+    "image_transformed\n",
+    "##\n",
+    "import spatialdata as sd\n",
+    "from napari_spatialdata import Interactive\n",
+    "\n",
+    "image_transformed0 = sd.models.Image2DModel.parse(\n",
+    "    image_transformed,\n",
+    "    dims=(\"y\", \"x\", \"c\"),\n",
+    "    transformations={\"global\": sd.transformations.Scale([0.5, 1.1], axes=(\"x\", \"y\"))},\n",
+    ")\n",
+    "image_transformed1 = sd.models.Image2DModel.parse(\n",
+    "    image_transformed.copy(),\n",
+    "    dims=(\"y\", \"x\", \"c\"),\n",
+    "    transformations={\"global\": sd.transformations.Translation([500, -1000], axes=(\"x\", \"y\"))},\n",
+    ")\n",
+    "image_transformed2 = sd.models.Image2DModel.parse(\n",
+    "    image_transformed.copy(),\n",
+    "    dims=(\"y\", \"x\", \"c\"),\n",
+    "    transformations={\n",
+    "        \"global\": sd.transformations.Affine(\n",
+    "            [[0.25, 0.5, -500], [1, 0.125, -1000], [0, 0, 1]], input_axes=(\"x\", \"y\"), output_axes=(\"x\", \"y\")\n",
+    "        )\n",
+    "    },\n",
+    ")\n",
+    "sdata = sd.SpatialData(images={\"im0\": image_transformed0, \"im1\": image_transformed1, \"im2\": image_transformed2})\n",
+    "sdata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>name</th>\n",
+       "      <th>X</th>\n",
+       "      <th>Y</th>\n",
+       "      <th>Z</th>\n",
+       "      <th>um/px</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>im0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>im1</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>im2</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  name    X    Y    Z  um/px\n",
+       "0  im0  0.0  0.0  0.0    1.0\n",
+       "1  im1  0.0  0.0  0.0    1.0\n",
+       "2  im2  0.0  0.0  0.0    1.0"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "coords = pd.DataFrame(\n",
+    "    {'name': ['im0', 'im1', 'im2'],\n",
+    "     'X': [0., 0., 0.],\n",
+    "     'Y': [0., 0., 0.],\n",
+    "     'Z': [0., 0., 0.],\n",
+    "     'um/px': [1.0, 1.0, 1.0]}\n",
+    ")\n",
+    "coords"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dataset cleaning\n",
+    "In this particular dataset, the first tile is actually an outlier with incorrect metadata. We remove it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[0., 0.],\n",
+       "       [0., 0.],\n",
+       "       [0., 0.]])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "normalized_coords = normalize_coords_to_pixel(coords).to_numpy()\n",
+    "normalized_coords"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this particular data set, we need to perform a few pre-processing steps on each image, such as cropping away a black border on one side of the image and transposing the image to account for the camera orientation relative to the stage. \n",
+    "We configure a `_load_image` image function that performs these pre-processing steps for us:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_transforms = [crop_black_border, \n",
+    "                    transpose]\n",
+    "_load_image = partial(load_image, transforms=input_transforms)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the next step we load the first image to determine the shape of the image after the pre-processing steps. \n",
+    "Here, we assume that all tiles have the same shape. (This is not strictly necessary). "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For each input tile, find out where its corners map after the transformation that puts it in a joint coordinate system.\n",
+    "Here, the transformation is a simple translation, but in general it could also be a more general affine transform (i.e. including rotations and scaling) or even a perspective transform (for photo mosaics). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transforms = {}\n",
+    "for k in ['im0', 'im1', 'im2']:\n",
+    "    mat = sdata.images[k].transform['global'].to_affine_matrix(('x', 'y'), ('x', 'y'))\n",
+    "    transforms[k] = AffineTransform(mat)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(5120, 5120)\n",
+      "(5120, 5120)\n",
+      "(5120, 5120)\n"
+     ]
+    }
+   ],
+   "source": [
+    "tiles = {}\n",
+    "for k in ['im0', 'im1', 'im2']:\n",
+    "    tile_shape = sdata.images[k].shape[1:]  # TODO: enable channels\n",
+    "    print(tile_shape)\n",
+    "    tiles[k] = get_transformed_array_corners(tile_shape, transforms[k])[:, ::-1]  # invert"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's create shapely objects from the numpy arrays that hold the corner points.\n",
+    "If we also include the a shapely Point at (0,0) we can visualize where the tiles are with respect to the origin of the joint coordinate system. (As it may be hard to spot: look for the origin at he bottom left of the next cell's output)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"300\" height=\"300\" viewBox=\"-765.28 -5897.28 6650.5599999999995 7162.5599999999995\" preserveAspectRatio=\"xMinYMin meet\"><g transform=\"matrix(1,0,0,-1,0,-4632.0)\"><g><circle cx=\"0.0\" cy=\"0.0\" r=\"71.62559999999999\" stroke=\"#555555\" stroke-width=\"23.8752\" fill=\"#66cc99\" opacity=\"0.6\" /><g><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"47.7504\" opacity=\"0.6\" d=\"M 0.0,-0.0 L 2560.0,-0.0 L 2560.0,-5632.0 L 0.0,-5632.0 L 0.0,-0.0 z\" /><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"47.7504\" opacity=\"0.6\" d=\"M 500.0,1000.0 L 5620.0,1000.0 L 5620.0,-4120.0 L 500.0,-4120.0 L 500.0,1000.0 z\" /><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"47.7504\" opacity=\"0.6\" d=\"M -500.0,1000.0 L 780.0,-4120.0 L 3340.0,-4760.0 L 2060.0,360.0 L -500.0,1000.0 z\" /></g></g></g></svg>"
+      ],
+      "text/plain": [
+       "<GEOMETRYCOLLECTION (POINT (0 0), GEOMETRYCOLLECTION (POLYGON ((0 0, 2560 0,...>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tiles_shapely = [numpy_shape_to_shapely(s) for s in tiles.values()]\n",
+    "origin = Point(0,0)\n",
+    "GeometryCollection((origin, GeometryCollection(tiles_shapely)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Determine required shape of the dask output array.\n",
+    "\n",
+    "As we can see above, the image tiles are a fair way away from the origin. In the fused imgage, we don't want to include a lot of empty space.\n",
+    "\n",
+    "We examine bounds of the stitched area to determine the size of the Zarr array we require.\n",
+    "We also find a translation that shifts the top-left corner of all tiles to (0,0) and update the initial transforms by chaining them with this translation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(6632, 6120)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "all_bboxes = np.vstack(list(tiles.values()))\n",
+    "all_min = all_bboxes.min(axis=0)\n",
+    "all_max = all_bboxes.max(axis=0)\n",
+    "stitched_shape=tuple(np.ceil(all_max-all_min).astype(int))\n",
+    "stitched_shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[   1.,   -0., 1000.],\n",
+       "       [   0.,    1.,  500.],\n",
+       "       [   0.,    0.,    1.]])"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "shift_to_origin = AffineTransform(translation=-all_min)\n",
+    "shift_to_origin.params"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transforms_with_shift = [shift_to_origin + t for t in transforms.values()]\n",
+    "shifted_tiles = [get_transformed_array_corners(tile_shape, t)[:, ::-1] for t in transforms_with_shift]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We visualize the tile boundaries after the additional translation to verify that the corner of the mosaic is now at the origin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"300\" height=\"300\" viewBox=\"-267.28000000000003 -6449.28 7154.5599999999995 7216.5599999999995\" preserveAspectRatio=\"xMinYMin meet\"><g transform=\"matrix(1,0,0,-1,0,-5682.0)\"><g><circle cx=\"0.0\" cy=\"0.0\" r=\"72.1656\" stroke=\"#555555\" stroke-width=\"24.0552\" fill=\"#66cc99\" opacity=\"0.6\" /><g><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"48.1104\" opacity=\"0.6\" d=\"M 500.0,-550.0 L 3060.0,-550.0 L 3060.0,-6182.0 L 500.0,-6182.0 L 500.0,-550.0 z\" /><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"48.1104\" opacity=\"0.6\" d=\"M 1500.0,500.0 L 6620.0,500.0 L 6620.0,-4620.0 L 1500.0,-4620.0 L 1500.0,500.0 z\" /><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"48.1104\" opacity=\"0.6\" d=\"M 0.0,-62.5 L 1280.0,-5182.5 L 3840.0,-5822.5 L 2560.0,-702.5 L 0.0,-62.5 z\" /></g></g></g></svg>"
+      ],
+      "text/plain": [
+       "<GEOMETRYCOLLECTION (POINT (0 0), GEOMETRYCOLLECTION (POLYGON ((500 -550, 30...>"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tiles_shifted_shapely = [numpy_shape_to_shapely(s) for s in shifted_tiles]\n",
+    "origin = Point(0,0)\n",
+    "GeometryCollection((origin, GeometryCollection(tiles_shifted_shapely)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a dask array for the fused image\n",
+    "\n",
+    "We need to decide on a suitable chunk size. Later, each chunk will be processed separately and possibly in parallel using `map_blocks`. Choosing a chunk size is a trade-off between memory and performance. \n",
+    "If we choose the chunk size too large, the memory requirements for each chunk increase. \n",
+    "If we choose the chunk size too small, the situation where a tile intersects multiple chunks will occur more often. This potentially leads to multiple disk access for the same tile.\n",
+    "\n",
+    "Other considerations for the chunk size is the chunking that is needed in the output file (we use a zarr array), e.g. for a viewer such as napari.\n",
+    "\n",
+    "On my machine I empirically found (4096, 4096)  a good trade-off, but you can experiment with other chunk sizes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chunk_size = (1024 * 2, 1024 * 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((2048, 2048, 2048, 488), (2048, 2048, 2024))"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chunks = normalize_chunks(chunk_size,shape=tuple(stitched_shape))\n",
+    "chunks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We just convince ourselves that all the chunks taken together have the same size as `stitched_shape`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([6632, 6120]), (6632, 6120))"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "computed_shape = np.array(list(map(sum, chunks)))\n",
+    "assert np.all(np.array(stitched_shape) == computed_shape)\n",
+    "computed_shape, stitched_shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compute tuples of coorindates with which we can slice the destination array to get a single chunk:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[((0, 2048), (0, 2048)),\n",
+       " ((0, 2048), (2048, 4096)),\n",
+       " ((0, 2048), (4096, 6120)),\n",
+       " ((2048, 4096), (0, 2048)),\n",
+       " ((2048, 4096), (2048, 4096)),\n",
+       " ((2048, 4096), (4096, 6120)),\n",
+       " ((4096, 6144), (0, 2048)),\n",
+       " ((4096, 6144), (2048, 4096)),\n",
+       " ((4096, 6144), (4096, 6120)),\n",
+       " ((6144, 6632), (0, 2048)),\n",
+       " ((6144, 6632), (2048, 4096)),\n",
+       " ((6144, 6632), (4096, 6120))]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chunk_boundaries = list(get_chunk_coordinates(stitched_shape, chunk_size))\n",
+    "chunk_boundaries"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We also create shapely objects of the chunks so we can visualize them in the notebook and to make it easier to determine which tiles intersect a given chunk and therefore need to be processed in that block."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chunk_shapes = list(map(get_rect_from_chunk_boundary, chunk_boundaries))\n",
+    "chunks_shapely = [numpy_shape_to_shapely(c) for c in chunk_shapes]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can visualize both the chunks and the tiles to see the overlaps:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"300\" height=\"300\" viewBox=\"-285.24 -6916.24 7190.48 7701.48\" preserveAspectRatio=\"xMinYMin meet\"><g transform=\"matrix(1,0,0,-1,0,-6131.0)\"><g><circle cx=\"0.0\" cy=\"0.0\" r=\"77.0148\" stroke=\"#555555\" stroke-width=\"25.671599999999998\" fill=\"#66cc99\" opacity=\"0.6\" /><g><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"51.343199999999996\" opacity=\"0.6\" d=\"M 500.0,-550.0 L 3060.0,-550.0 L 3060.0,-6182.0 L 500.0,-6182.0 L 500.0,-550.0 z\" /><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"51.343199999999996\" opacity=\"0.6\" d=\"M 1500.0,500.0 L 6620.0,500.0 L 6620.0,-4620.0 L 1500.0,-4620.0 L 1500.0,500.0 z\" /><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"51.343199999999996\" opacity=\"0.6\" d=\"M 0.0,-62.5 L 1280.0,-5182.5 L 3840.0,-5822.5 L 2560.0,-702.5 L 0.0,-62.5 z\" /></g><g><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"51.343199999999996\" opacity=\"0.6\" d=\"M 0.0,0.0 L 0.0,-2047.0 L 2047.0,-2047.0 L 2047.0,0.0 L 0.0,0.0 z\" /><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"51.343199999999996\" opacity=\"0.6\" d=\"M 2048.0,0.0 L 2048.0,-2047.0 L 4095.0,-2047.0 L 4095.0,0.0 L 2048.0,0.0 z\" /><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"51.343199999999996\" opacity=\"0.6\" d=\"M 4096.0,0.0 L 4096.0,-2047.0 L 6119.0,-2047.0 L 6119.0,0.0 L 4096.0,0.0 z\" /><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"51.343199999999996\" opacity=\"0.6\" d=\"M 0.0,-2048.0 L 0.0,-4095.0 L 2047.0,-4095.0 L 2047.0,-2048.0 L 0.0,-2048.0 z\" /><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"51.343199999999996\" opacity=\"0.6\" d=\"M 2048.0,-2048.0 L 2048.0,-4095.0 L 4095.0,-4095.0 L 4095.0,-2048.0 L 2048.0,-2048.0 z\" /><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"51.343199999999996\" opacity=\"0.6\" d=\"M 4096.0,-2048.0 L 4096.0,-4095.0 L 6119.0,-4095.0 L 6119.0,-2048.0 L 4096.0,-2048.0 z\" /><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"51.343199999999996\" opacity=\"0.6\" d=\"M 0.0,-4096.0 L 0.0,-6143.0 L 2047.0,-6143.0 L 2047.0,-4096.0 L 0.0,-4096.0 z\" /><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"51.343199999999996\" opacity=\"0.6\" d=\"M 2048.0,-4096.0 L 2048.0,-6143.0 L 4095.0,-6143.0 L 4095.0,-4096.0 L 2048.0,-4096.0 z\" /><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"51.343199999999996\" opacity=\"0.6\" d=\"M 4096.0,-4096.0 L 4096.0,-6143.0 L 6119.0,-6143.0 L 6119.0,-4096.0 L 4096.0,-4096.0 z\" /><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"51.343199999999996\" opacity=\"0.6\" d=\"M 0.0,-6144.0 L 0.0,-6631.0 L 2047.0,-6631.0 L 2047.0,-6144.0 L 0.0,-6144.0 z\" /><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"51.343199999999996\" opacity=\"0.6\" d=\"M 2048.0,-6144.0 L 2048.0,-6631.0 L 4095.0,-6631.0 L 4095.0,-6144.0 L 2048.0,-6144.0 z\" /><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"51.343199999999996\" opacity=\"0.6\" d=\"M 4096.0,-6144.0 L 4096.0,-6631.0 L 6119.0,-6631.0 L 6119.0,-6144.0 L 4096.0,-6144.0 z\" /></g></g></g></svg>"
+      ],
+      "text/plain": [
+       "<GEOMETRYCOLLECTION (POINT (0 0), GEOMETRYCOLLECTION (POLYGON ((500 -550, 30...>"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "GeometryCollection([origin, \n",
+    "                    GeometryCollection(tiles_shifted_shapely), \n",
+    "                    GeometryCollection(chunks_shapely),])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta = {}\n",
+    "for tile_shifted_shapely, file, transform in zip(tiles_shifted_shapely, \n",
+    "                                                 [v[0] for v in sdata.images.values()],\n",
+    "                                                 transforms_with_shift):\n",
+    "    meta[tile_shifted_shapely] = {'file':file, 'transform':transform}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for chunk_shapely, chunk_boundary  in zip(chunks_shapely, chunk_boundaries):\n",
+    "    meta[chunk_shapely] = {'chunk_boundary': chunk_boundary}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we create a data structure that holds alls the information regarding the tiles that are needed to perform the fusion of arrays ins a given chunk.\n",
+    "\n",
+    "We choose a dictionary that is indexed by the top-left coordinate tuple of each chunk."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chunk_tiles = find_chunk_tile_intersections(tiles_shifted_shapely, chunks_shapely, fuse_info=meta)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We inspect one of these dict entries to see that it contains a list of tuples with information about each intersecting tile: file path and affine transformation matrix for that particular tile."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At this stage, we can use `map_blocks` to calculate the fused image chunk by chunk.\n",
+    "To do so, we pass a function `_fuse_func` to `map_blocks` that will get called for each chunk.\n",
+    "\n",
+    "You may want to closely inspect `fuse_func` that we imported in `fuse.py`. It takes \n",
+    "care of loading all the tiles for the particular chunk it is processing and applying \n",
+    "the respective affine transforms. It also applies an additional translation to the individual affine\n",
+    "transforms, to account for the fact that the coordinates in the chunk are relative to the chunks location\n",
+    "in the target array.\n",
+    "\n",
+    "By processing each chunk individually, only the source tiles overlapping that particular chunk will have to be loaded into memory. Thus we can generate a large fused array even on a machine with limited RAM. This is an example of using dask for [\"out-of-core\"](https://en.wikipedia.org/wiki/External_memory_algorithm) processing.\n",
+    "\n",
+    "Using `partial` function evaluation we set some of the arguments of `fuse_func`, for example the image file loader. It is this partially evaluated function we pass to `map_blocks`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_fuse_func=partial(fuse_func, \n",
+    "                   imload_fn=None)\n",
+    "\n",
+    "target_array = da.map_blocks(func=_fuse_func,\n",
+    "                             chunks=chunks, \n",
+    "                             input_tile_info=chunk_tiles,\n",
+    "                             dtype=np.uint8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Up to this point, the computation that maps the tiles into the destination array hasn't been computed.\n",
+    "We can trigger the computation by writing the array into a `zarr` file on disk."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Processing chunk at (0, 0)Processing chunk at (0, 2048)\n",
+      "\n",
+      "Processing chunk at (0, 4096)\n",
+      "Processing chunk at (2048, 0)\n",
+      "Processing chunk at (2048, 2048)\n",
+      "Processing chunk at (2048, 4096)\n",
+      "Processing chunk at (4096, 0)\n",
+      "Processing chunk at (4096, 2048)\n",
+      "Processing chunk at (4096, 4096)\n",
+      "Processing chunk at (6144, 0)\n",
+      "Processing chunk at (6144, 2048)\n",
+      "Processing chunk at (6144, 4096)\n"
+     ]
+    }
+   ],
+   "source": [
+    "target_array.to_zarr(\"fused.zarr\", overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The command above writes a simple chunked zarr array. For large mosaics it may be useful to write a multi-resolution image pyramid, e.g. using this https://github.com/aeisenbarth/ngff-writer package to write the dask array to a multi-resolution `.ome.zarr` (an emerging NGFF file format).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you want to look at at the zarr array, you can use napari which supports loading zarr files:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import napari\n",
+    "from napari.utils import nbscreenshot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Image layer 'Fused' at 0x29110ba60>"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "v = napari.Viewer()\n",
+    "v.add_image(da.from_zarr(\"fused.zarr\"), name=\"Fused\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<napari_spatialdata.interactive.Interactive at 0x28b366d10>"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Interactive(sdata)"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "8c1da9b333bd16eca91c483de28cf1e3bdef92ae84368abdb550f55cbacd6d65"
+  },
+  "kernelspec": {
+   "display_name": "hackathon",
+   "language": "python",
+   "name": "hackathon"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Requires https://github.com/VolkerH/DaskFusion

Current TODOs:
- [ ] enable channel axis
- [ ] blending modes


To work with `shapely>=2.0`, one needs to modify this [original function](https://github.com/VolkerH/DaskFusion/blob/main/utils/chunks.py#L40-L70):
```python
def find_chunk_tile_intersections(
    tiles_shapely: List["shapely.geometry.base.BaseGeometry"],
    chunks_shapely: List["shapely.geometry.base.BaseGeometry"],
    fuse_info: Dict["shapely.geometry.base.BaseGeometry", Any],
) -> Dict[Tuple[int, int], Tuple[str, np.ndarray]]:
    """
    For each output array chunk, find the intersecting image tiles

    Args:
        tile_shapes: Contains the shapely objects corresponding to transformed image outlines.
        chunk_shapes: Contains the shapely objects representing dask array chunks.
        fuse_info: TODO.

    Returns:
         The chunk_to_tiles dictionary, which has the chunk anchor points as keys and tuples of
         image file names and their corresponding affine transform matrix as values.
    """
    chunk_to_tiles = {}
    tile_tree = STRtree(tiles_shapely)

    for chunk_shape in chunks_shapely:
        chunk_boundary = fuse_info[chunk_shape]["chunk_boundary"]
        anchor_point = (chunk_boundary[0][0], chunk_boundary[1][0])
        intersecting_tiles = tile_tree.query(chunk_shape)
        chunk_to_tiles[anchor_point] = [
            ((fuse_info[tiles_shapely[ix]]["file"], fuse_info[tiles_shapely[ix]]["transform"]))
            for ix in intersecting_tiles
        ]
    return chunk_to_tiles
```