### PR TITLE
using spatialdata-io for the visium dataset

### DIFF
--- a/visium/download.py
+++ b/visium/download.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 
 import os
-import shutil
 from pathlib import Path
-import scanpy as sc
 
 import sys
 
@@ -15,12 +13,6 @@ main_dir = Path().resolve() / "data"
 print(main_dir)
 main_dir.mkdir(parents=True, exist_ok=True)
 
-image_dir = main_dir / "images"
-image_dir.mkdir(parents=True, exist_ok=True)
-
-table_dir = main_dir / "tables"
-table_dir.mkdir(parents=True, exist_ok=True)
-
 
 brainfile = main_dir / "mousebrain.zip"
 download(
@@ -29,19 +21,3 @@ download(
     desc="data",
 )
 unzip(brainfile, main_dir)
-
-for lib in os.scandir(
-    main_dir / os.path.join("mouse_brain_visium_wo_cloupe_data", "rawdata")
-):
-    if not lib.name.startswith("."):
-        shutil.copy2(
-            main_dir / os.path.join(lib.path, "spatial", "tissue_hires_image.png"),
-            main_dir / os.path.join("images", lib.name + ".png"),
-        )
-
-        adata = sc.read_visium(main_dir / lib.path)
-        adata.write_h5ad(
-            main_dir / os.path.join("tables", lib.name + ".h5ad"),
-            compression="gzip",
-            compression_opts=9,
-        )

--- a/visium/to_zarr.py
+++ b/visium/to_zarr.py
@@ -8,6 +8,7 @@ from spatialdata.transformations.transformations import Scale, Identity
 import re
 import os
 from tqdm import tqdm
+from spatialdata_io import visium
 
 ##
 path = Path().resolve()
@@ -18,72 +19,11 @@ if not str(path).endswith("visium"):
 path_read = path / "data"
 path_write = path / "data.zarr"
 
-libraries = [re.sub(".h5ad", "", i) for i in os.listdir(path_read / "tables")][:2]
-
 ##
-table_list = []
-images = {}
-shapes = {}
-for lib in tqdm(libraries, desc="loading visium libraries"):
-    # prepare table
-    table = ad.read_h5ad(path_read / "tables" / f"{lib}.h5ad")
-    table.var_names_make_unique()
-    table.obs["annotating"] = f'{lib}_shapes'
-    table.obs["library"] = lib
-    table.obs["spot_id"] = np.arange(len(table))
-    table_list.append(table)
-
-    # setup
-    lib_keys = list(table.uns["spatial"].keys())
-    assert len(lib_keys) == 1
-    lib_key = lib_keys[0]
-
-    # prepare image transformation
-    scale_factors = np.array(
-        [1 / table.uns["spatial"][lib_key]["scalefactors"]["tissue_hires_scalef"]] * 2
-    )
-    transform = Scale(scale=scale_factors, axes=('y', 'x'))
-
-    # prepare image
-    img = table.uns["spatial"][lib_key]["images"]["hires"]
-    assert img.dtype == np.float32 and np.min(img) >= 0.0 and np.max(img) <= 1.0
-    scaled = (img * 255).astype(np.uint8)
-    scaled = sd.models.Image2DModel.parse(scaled, transformations={lib: transform}, dims=("y", "x", "c"))
-    images[f'{lib}_image'] = scaled
-
-    # prepare circles
-    diameter = table.uns["spatial"][lib_key]["scalefactors"]["spot_diameter_fullres"]
-    shape_regions = sd.models.ShapesModel.parse(
-        table.obsm["spatial"],
-        geometry=0,
-        radius=diameter / 2,
-        transformations={lib: Identity()},
-    )
-    shapes[f'{lib}_shapes'] = shape_regions
-
-
-table = ad.concat(
-    table_list,
-    label="library",
-    keys=libraries,
-)
-
-del table.obsm["spatial"]
-adata = sd.models.TableModel.parse(
-    table,
-    region=[f'{lib}_shapes' for lib in libraries],
-    region_key="annotating",
-    instance_key="spot_id",
-)
-
-sdata = sd.SpatialData(
-    table=table,
-    images=images,
-    shapes=shapes,
-)
+sdata = visium(path_read / 'mouse_brain_visium_wo_cloupe_data/rawdata/ST8059048', dataset_id='ST8059048')
 print(sdata)
 
-##
+#
 if path_write.exists():
     shutil.rmtree(path_write)
 sdata.write(path_write)


### PR DESCRIPTION
Removed the manual construction of the `visium` dataset and using the `spatialdata-io` library instead. In this way we test two types of datasets: one as downloaded from 10x Genomics (`visium_io`) and one as given as output form `spaceranger` (`visium`). 