### PR TITLE
Add SpaceM datasets

### DIFF
--- a/spacem_helanih3t3/README.md
+++ b/spacem_helanih3t3/README.md
@@ -1,0 +1,31 @@
+### Data
+
+This is a metabolomics dataset from experiments on Hepa and NIH3T3 cells using the [SpaceM](https://doi.org/10.1038/s41592-021-01198-0) method, by [Alexandrov group, EMBL](https://www.embl.org/groups/alexandrov/).
+
+The data consist of the following items:
+
+- coordinate systems:
+  Each set of processed images/labels is registered in a corresponding coordinate system with matching prefix.
+  (This is because "global" is the default coordinate system of incoming unregistered data and is treated unmutable).
+- images:
+  - `….pre_maldi`: Microscopy, with `Trans` and `GFP` channels
+  - `….post_maldi`: Microscopy after MALDI measurements, with `Trans` and `Dapi` channels
+- labels:
+  - `….cells`: Segmentation of pre-MALDI images
+  - `….ablation_marks`: Segmentation of post-MALDI images
+- shapes:
+  - `….layout`: Bounding boxes of wells on a slide
+  - `….maldi_regions`: Bounding boxes for the MALDI measurements
+- tables:
+  - `table`:
+    - for all annotated elements: `project_id`, `slide_id`, `well_id`, `maldi_region_id`
+    - for segmentations:
+      - `object_type`, `replicate`, `treatment`
+      - scikit-image region properties
+      - `X`: MALDI ion intensities
+
+### Download
+
+The dataset is already natively in SpatialData 0.1.2 format.
+
+Download the data with `download.py`, (`write_zarr.py` exists solely for consistency).

--- a/spacem_helanih3t3/README.md
+++ b/spacem_helanih3t3/README.md
@@ -28,4 +28,4 @@ The data consist of the following items:
 
 The dataset is already natively in SpatialData 0.1.2 format.
 
-Download the data with `download.py`, (`write_zarr.py` exists solely for consistency).
+Download the data with `download.py`, (`to_zarr.py` exists solely for consistency).

--- a/spacem_helanih3t3/download.py
+++ b/spacem_helanih3t3/download.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+
+URL = "TODO",
+
+os.chdir(os.path.dirname(__file__))
+command = f"curl {url} --output 'data.zip'"
+subprocess.run(command, shell=True, check=True)
+subprocess.run("unzip -f -o data.zip", shell=True, check=True)
+subprocess.run("mv spatialdata.zarr data.zarr", shell=True, check=True)

--- a/spacem_helanih3t3/download.py
+++ b/spacem_helanih3t3/download.py
@@ -2,10 +2,10 @@
 import os
 import subprocess
 
-URL = "TODO",
+URL = "https://s3.embl.de/spatialdata/raw_data/20221014_HeLaNIH3T3.small.zip"
 
 os.chdir(os.path.dirname(__file__))
-command = f"curl {url} --output 'data.zip'"
+command = f"curl {URL} --output 'data.zip'"
 subprocess.run(command, shell=True, check=True)
-subprocess.run("unzip -f -o data.zip", shell=True, check=True)
+subprocess.run("unzip -o data.zip", shell=True, check=True)
 subprocess.run("mv spatialdata.zarr data.zarr", shell=True, check=True)

--- a/spacem_helanih3t3/to_zarr.py
+++ b/spacem_helanih3t3/to_zarr.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import spatialdata as sd
+
+# Dataset is already in SpatialData format.
+path_read = Path(__file__).parent / "data.zarr"
+assert path_read.exists()
+
+print(f'view with "python -m napari_spatialdata view data.zarr"')
+
+# Test reading
+sdata = sd.SpatialData.read("./data.zarr")
+print(sdata)

--- a/spacem_scseahorse1/README.md
+++ b/spacem_scseahorse1/README.md
@@ -1,0 +1,31 @@
+### Data
+
+This is a metabolomics dataset from single-cell Seahorse experiments on T-cells using the [SpaceM](https://doi.org/10.1038/s41592-021-01198-0) method, by [Alexandrov group, EMBL](https://www.embl.org/groups/alexandrov/).
+
+The data consist of the following items:
+
+- coordinate systems:
+  Each set of processed images/labels is registered in a corresponding coordinate system with matching prefix.
+  (This is because "global" is the default coordinate system of incoming unregistered data and is treated unmutable).
+- images:
+  - `….pre_maldi`: Microscopy, with `Trans` and `GFP` channels
+  - `….post_maldi`: Microscopy after MALDI measurements, with `Trans` and `Dapi` channels
+- labels:
+  - `….cells`: Segmentation of pre-MALDI images
+  - `….ablation_marks`: Segmentation of post-MALDI images
+- shapes:
+  - `….layout`: Bounding boxes of wells on a slide
+  - `….maldi_regions`: Bounding boxes for the MALDI measurements
+- tables:
+  - `table`:
+    - for all annotated elements: `project_id`, `slide_id`, `well_id`, `maldi_region_id`
+    - for segmentations:
+      - `object_type`, `replicate`, `treatment`
+      - scikit-image region properties
+      - `X`: MALDI ion intensities
+
+### Download
+
+The dataset is already natively in SpatialData 0.1.2 format.
+
+Download the data with `download.py`, (`write_zarr.py` exists solely for consistency).

--- a/spacem_scseahorse1/README.md
+++ b/spacem_scseahorse1/README.md
@@ -28,4 +28,4 @@ The data consist of the following items:
 
 The dataset is already natively in SpatialData 0.1.2 format.
 
-Download the data with `download.py`, (`write_zarr.py` exists solely for consistency).
+Download the data with `download.py`, (`to_zarr.py` exists solely for consistency).

--- a/spacem_scseahorse1/download.py
+++ b/spacem_scseahorse1/download.py
@@ -2,10 +2,10 @@
 import os
 import subprocess
 
-URL = "TODO",
+URL = "https://s3.embl.de/spatialdata/raw_data/20220121_ScSeahorse1.small.zip"
 
 os.chdir(os.path.dirname(__file__))
-command = f"curl {url} --output 'data.zip'"
+command = f"curl {URL} --output 'data.zip'"
 subprocess.run(command, shell=True, check=True)
-subprocess.run("unzip -f -o data.zip", shell=True, check=True)
+subprocess.run("unzip -o data.zip", shell=True, check=True)
 subprocess.run("mv spatialdata.zarr data.zarr", shell=True, check=True)

--- a/spacem_scseahorse1/download.py
+++ b/spacem_scseahorse1/download.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+
+URL = "TODO",
+
+os.chdir(os.path.dirname(__file__))
+command = f"curl {url} --output 'data.zip'"
+subprocess.run(command, shell=True, check=True)
+subprocess.run("unzip -f -o data.zip", shell=True, check=True)
+subprocess.run("mv spatialdata.zarr data.zarr", shell=True, check=True)

--- a/spacem_scseahorse1/to_zarr.py
+++ b/spacem_scseahorse1/to_zarr.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import spatialdata as sd
+
+# Dataset is already in SpatialData format.
+path_read = Path(__file__).parent / "data.zarr"
+assert path_read.exists()
+
+print(f'view with "python -m napari_spatialdata view data.zarr"')
+
+# Test reading
+sdata = sd.SpatialData.read("./data.zarr")
+print(sdata)


### PR DESCRIPTION
This PR adds two SpaceM datasets as examples for metabolomics.

SpaceM datasets natively use the SpatialData format, so actually only downloading is needed but no conversion. Still, I kept the pattern of both `download.py` and `to_zarr.py` for consistency.

Work still needed:
- [x] (BLOCKER) Datasets were generated with spatialdata 0.1.2 and use `.` in element names, which is incompatible with the current version. https://github.com/scverse/spatialdata/issues/624 needs to be solved first, or the elements in the dataset need to be renamed.
- [x] Transfer datasets to persistent, public storage. (I shared the datasets with @LucaMarconato .)
- [x] Update URLs in the both download.py scripts
- [x] Test the scripts in the workflow