### PR TITLE
add visiumhd crc2 dataset

### DIFF
--- a/visium_hd_3.0.0_crc2/download.py
+++ b/visium_hd_3.0.0_crc2/download.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+##
+import os
+import subprocess
+from pathlib import Path
+import shutil
+
+import sys
+
+sys.path.insert(1, os.path.join(sys.path[0], Path(__file__).parent.parent.resolve()))
+
+from utils import download
+
+##
+
+# from https://www.10xgenomics.com/products/visium-hd-spatial-gene-expression/dataset-human-crc
+# Visium HD, Sample P2 CRC
+
+# Input Files
+
+urls = [
+    "https://cf.10xgenomics.com/samples/spatial-exp/3.0.0/Visium_HD_Human_Colon_Cancer_P2/Visium_HD_Human_Colon_Cancer_P2_tissue_image.btf",
+    "https://cf.10xgenomics.com/samples/spatial-exp/3.0.0/Visium_HD_Human_Colon_Cancer_P2/Visium_HD_Human_Colon_Cancer_P2_cloupe_008um.cloupe",
+    "https://cf.10xgenomics.com/samples/spatial-exp/3.0.0/Visium_HD_Human_Colon_Cancer_P2/Visium_HD_Human_Colon_Cancer_P2_feature_slice.h5",
+    "https://cf.10xgenomics.com/samples/spatial-exp/3.0.0/Visium_HD_Human_Colon_Cancer_P2/Visium_HD_Human_Colon_Cancer_P2_spatial.tar.gz",
+    "https://cf.10xgenomics.com/samples/spatial-exp/3.0.0/Visium_HD_Human_Colon_Cancer_P2/Visium_HD_Human_Colon_Cancer_P2_binned_outputs.tar.gz"
+]
+
+##
+os.makedirs("data", exist_ok=True)
+for url in urls:
+    print(url)
+    name = Path(url).name
+    download(url, os.path.join("data", name), name)
+
+files = [
+    "Visium_HD_Human_Colon_Cancer_P2_spatial.tar.gz",
+    "Visium_HD_Human_Colon_Cancer_P2_binned_outputs.tar.gz",
+]
+for file in files:
+    subprocess.run(f"tar -xzf data/{file} -C data", shell=True, check=True)
+    subprocess.run(f"rm data/{file}", shell=True, check=True)
+
+for dir in list(Path("data/binned_outputs").glob("*")):
+    if not(Path("data") / dir.name).exists():
+        shutil.move(dir,"data")
+subprocess.run(f"rm -r data/binned_outputs", shell=True, check=True)

--- a/visium_hd_3.0.0_crc2/to_zarr.py
+++ b/visium_hd_3.0.0_crc2/to_zarr.py
@@ -21,6 +21,8 @@ sdata = visium_hd(
     bin_size=8
 )
 
+sdata = sdata.filter_by_coordinate_system("downscaled_hires")
+
 ##
 if path_write.exists():
     shutil.rmtree(path_write)

--- a/visium_hd_3.0.0_crc2/to_zarr.py
+++ b/visium_hd_3.0.0_crc2/to_zarr.py
@@ -1,0 +1,34 @@
+##
+from spatialdata_io import visium_hd
+import spatialdata as sd
+
+##
+from pathlib import Path
+import shutil
+
+##
+path = Path().resolve()
+# luca's workaround for pycharm
+if not str(path).endswith("visium_hd_3.0.0_crc2"):
+    path /= "visium_hd_3.0.0_crc2"
+    assert path.exists()
+path_read = path / "data"
+path_write = path / "data.zarr"
+
+##
+sdata = visium_hd(
+    path_read,
+    bin_size=8
+)
+
+##
+if path_write.exists():
+    shutil.rmtree(path_write)
+sdata.write(path_write)
+print("done")
+
+##
+print(f'view with "python -m napari_spatialdata view data.zarr"')
+sdata = sd.SpatialData.read(path_write)
+print(sdata)
+print("read")


### PR DESCRIPTION
This PR adds the crc2 visiumhd dataset which will be used in the tutorial notebook for the napari-spatialdata annotation widget. The dataset is subsetted to only include the hires image and the 8um bin data.