### PR TITLE
Avoid removing lowres transformation from visium

### DIFF
--- a/visium/to_zarr.py
+++ b/visium/to_zarr.py
@@ -31,18 +31,17 @@ sdataST8059050 = visium(
 # Each SpatialData object has 3 coordinate systems: 'global', 'downscaled_hires' and 'downscaled_lowres'.
 # Visium datasets generally are available with images (lowres and hires) and sometimes also a "full resolution" image,
 # which has an even greater resolution than the hires image. This dataset doesn't contain a full resolution image, so
-# let's drop the coordinate system "global", which would otherwise contain it. Let's also drop the coordinate system
-# "downscaled_lowres", which is not needed.
+# let's drop the coordinate system "global", which would otherwise contain it.
 # NOTE: in future version of the Visium reader only one coordinate system will be used, containing all the images. We
 # are keeping the three coordinate systems for legacy reasons for the time being.
 
 for el in sdataST8059048._gen_spatial_element_values():
-    for cs_name in ["ST8059048", "ST8059048_downscaled_lowres"]:
+    for cs_name in ["ST8059048"]:
         if cs_name in sd.transformations.get_transformation(el, get_all=True):
             sd.transformations.remove_transformation(el, cs_name)
 
 for el in sdataST8059050._gen_spatial_element_values():
-    for cs_name in ["ST8059050", "ST8059050_downscaled_lowres"]:
+    for cs_name in ["ST8059050"]:
         if cs_name in sd.transformations.get_transformation(el, get_all=True):
             sd.transformations.remove_transformation(el, cs_name)
 


### PR DESCRIPTION
Closes #59 

Before the fix (with https://github.com/scverse/spatialdata/pull/1118), we would get:
```pytb
Traceback (most recent call last):
  File "/Users/macbook/embl/projects/basel/spatialdata-sandbox/visium/to_zarr.py", line 57, in <module>
    sdata = sd.concatenate([sdataST8059048, sdataST8059050], concatenate_tables=True)
  File "/Users/macbook/embl/projects/basel/spatialdata/src/spatialdata/_core/concatenate.py", line 208, in concatenate
    sdata = SpatialData(
        images=merged_images,
    ...<4 lines>...
        attrs=attrs,
    )
  File "/Users/macbook/embl/projects/basel/spatialdata/src/spatialdata/_core/spatialdata.py", line 142, in __init__
    with raise_validation_errors(
         ~~~~~~~~~~~~~~~~~~~~~~~^
        title="Cannot construct SpatialData object, input contains invalid elements.\n"
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        "For renaming, please see the discussion here https://github.com/scverse/spatialdata/discussions/707 .",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        exc_type=(ValueError, KeyError),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ) as collect_error:
    ^
  File "/Users/macbook/embl/projects/basel/spatialdata/src/spatialdata/_core/validation.py", line 386, in __exit__
    raise ValidationError(
    ...<2 lines>...
    )
spatialdata._core.validation.ValidationError: Cannot construct SpatialData object, input contains invalid elements.
For renaming, please see the discussion here https://github.com/scverse/spatialdata/discussions/707 .
To fix, run `spatialdata.utils.sanitize_table(adata)`.
  images/ST8059048_lowres_image: No transformation found for `<xarray.DataArray 'image' (c: 3, y: 600, x: 591)> Size: 1MB
dask.array<transpose, shape=(3, 600, 591), dtype=uint8, chunksize=(3, 600, 591), chunktype=numpy.ndarray>
Coordinates:
  * c        (c) <U1 12B 'r' 'g' 'b'
  * y        (y) float64 5kB 0.5 1.5 2.5 3.5 4.5 ... 596.5 597.5 598.5 599.5
  * x        (x) float64 5kB 0.5 1.5 2.5 3.5 4.5 ... 587.5 588.5 589.5 590.5
Attributes:
    transform:  {}`. At least one transformation is required for raster elements, e.g. images, labels.
  images/ST8059050_lowres_image: No transformation found for `<xarray.DataArray 'image' (c: 3, y: 600, x: 590)> Size: 1MB
dask.array<transpose, shape=(3, 600, 590), dtype=uint8, chunksize=(3, 600, 590), chunktype=numpy.ndarray>
Coordinates:
  * c        (c) <U1 12B 'r' 'g' 'b'
  * y        (y) float64 5kB 0.5 1.5 2.5 3.5 4.5 ... 596.5 597.5 598.5 599.5
  * x        (x) float64 5kB 0.5 1.5 2.5 3.5 4.5 ... 586.5 587.5 588.5 589.5
Attributes:
    transform:  {}`. At least one transformation is required for raster elements, e.g. images, labels.

Process finished with exit code 1

```

Now we get
```
SpatialData object, with associated Zarr store: /Users/macbook/embl/projects/basel/spatialdata-sandbox/visium/data.zarr
├── Images
│     ├── 'ST8059048_hires_image': DataArray[cyx] (3, 2000, 1969)
│     ├── 'ST8059048_lowres_image': DataArray[cyx] (3, 600, 591)
│     ├── 'ST8059050_hires_image': DataArray[cyx] (3, 2000, 1968)
│     └── 'ST8059050_lowres_image': DataArray[cyx] (3, 600, 590)
├── Shapes
│     ├── 'ST8059048': GeoDataFrame shape: (2987, 2) (2D shapes)
│     └── 'ST8059050': GeoDataFrame shape: (3497, 2) (2D shapes)
└── Tables
      └── 'table': AnnData (6484, 31053)
with coordinate systems:
    ▸ 'ST8059048', with elements:
        ST8059048_hires_image (Images), ST8059048 (Shapes)
    ▸ 'ST8059048_downscaled_lowres', with elements:
        ST8059048_lowres_image (Images), ST8059048 (Shapes)
    ▸ 'ST8059050', with elements:
        ST8059050_hires_image (Images), ST8059050 (Shapes)
    ▸ 'ST8059050_downscaled_lowres', with elements:
        ST8059050_lowres_image (Images), ST8059050 (Shapes)
```